### PR TITLE
Parse sections differently for Beaver (allow for [] in section names)

### DIFF
--- a/conf_d/__init__.py
+++ b/conf_d/__init__.py
@@ -52,10 +52,13 @@ class GlobSafeConfigParser(ConfigParser.RawConfigParser):
             # a section header or option header?
             else:
                 # is it a section header?
-                firstBrace = line.find('[') + 1
-                lastBrace = line.rfind(']')
-                if firstBrace != -1 and lastBrace != -1 and line.strip().find('[') == 0:
-                    sectname = line[firstBrace:lastBrace]
+                try:
+                  value = line[:line.index(';')].strip()
+                except ValueError: #no semicolon so no comments to strip off
+                  value = line.strip()
+
+                if  value[0]=='[' and value[-1]==']' and len(value)>2:
+                    sectname = value[1:-1]
                     if sectname in self._sections:
                         cursect = self._sections[sectname]
                     elif sectname == "DEFAULT":


### PR DESCRIPTION
In Beaver, you use globs in section names to assign different parameters to different files, which is great. Python's default ConfigParser, though, doesn't match brackets very well which limits what kind of globs you can use. (i.e. you can't do stuff like server[0-9] as a glob in the section.) I overrode the _read function from the python source to parse section headers differently which allows more glob usage.

Caveats: 1) we haven't pushed our Beaver setup to production with this so it hasn't been production vetted, but it's been handling well in our dev environment so far. 2) This is really an issue with Beaver, but it seemed easier to fix it in conf_d. I haven't tested it except with Beaver, though.

Lines 55-61 differ from the python source, the rest was copy/pasted.
