### PR TITLE
Allow using custom config parser

### DIFF
--- a/conf_d/__init__.py
+++ b/conf_d/__init__.py
@@ -7,7 +7,7 @@ __version__ = '0.0.3'
 
 class Configuration():
 
-    def __init__(self, name, path, parse=True, confd_path=None, conf_ext=None, main_defaults={}, section_defaults={}, main_parser=None, section_parser=None, path_from_main=None):
+    def __init__(self, name, path, parse=True, confd_path=None, conf_ext=None, main_defaults={}, section_defaults={}, main_parser=None, section_parser=None, path_from_main=None, config_parser=ConfigParser.ConfigParser):
         self._conf_ext = conf_ext
         self._config_sections = {}
         self._confd_path = confd_path
@@ -19,6 +19,7 @@ class Configuration():
         self._path = path
         self._section_defaults = section_defaults
         self._section_parser = section_parser
+        self._config_parser = config_parser
 
         if self._conf_ext:
             self._conf_ext = '.' + conf_ext.strip(".")
@@ -99,7 +100,7 @@ class Configuration():
                 self._config_sections.update(configs)
 
     def _parse_section(self, path, defaults={}, parser=None, only_section=None, remove_section=None):
-        config_parser = ConfigParser.ConfigParser(defaults)
+        config_parser = self._config_parser(defaults)
 
         if not path:
             raise IOError('No path specified: "%s"' % path)

--- a/conf_d/tests/test_configuration.py
+++ b/conf_d/tests/test_configuration.py
@@ -1,8 +1,12 @@
 # -*- coding: utf-8 -*-
+import ConfigParser
 import unittest
 
 from conf_d import Configuration
 
+class TestConfigParser(ConfigParser.ConfigParser):
+    def read(self, path):
+        raise NotImplementedError('Catch this')
 
 class ConfigurationTests(unittest.TestCase):
 
@@ -358,6 +362,16 @@ class ConfigurationTests(unittest.TestCase):
         self.assertEqual(True, conf.get('multiple_sections', 'main_key'))
         self.assertEqual(None, conf.get('derp', 'missing_key'))
         self.assertEqual(1, conf.get('another/conf', 'sleep'))
+
+    def test_custom_config_parser(self):
+        conf = Configuration(
+            name='multiple_sections',
+            path='./data/multiple_sections.ini',
+            config_parser=TestConfigParser,
+            parse=False
+        )
+
+        self.assertRaises(NotImplementedError, lambda: conf._parse_section(path='./data/multiple_sections.ini'))
 
     def test_readme(self):
         def digitize(config):


### PR DESCRIPTION
Instead of using ConfigParser.ConfigParser, let the user pass in a parser.

This is so I can add a custom parser to Beaver to allow parsing section names with brackets in them for better glob usage.
